### PR TITLE
Check for nil when checking whether to underline.

### DIFF
--- a/fish-colors.el
+++ b/fish-colors.el
@@ -75,7 +75,7 @@
     (string-join `(,(when (memq slant '( roman italic oblique
                                          reverse-italic reverse-oblique))
                       "--italic")
-                   ,(when (not (memq underline '(unspecified :unspecified)))
+                   ,(when (not (memq underline '(unspecified :unspecified nil)))
                       "--underline")
                    ,(when (memq weight '( semi-bold bold extra-bold ultra-bold
                                           black))


### PR DESCRIPTION
In my last pull request, I missed that the underline attribute can also be nil. 
Sorry about that.